### PR TITLE
Update CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,9 +45,17 @@ export(EXPORT ompx
 
 # https://cmake.org/cmake/help/latest/guide/importing-exporting/index.html#creating-packages
 # Package file
-configure_package_config_file(${CMAKE_CURRENT_SOURCE_DIR}/cmake/config.cmake.in
+if (LIBOMPX_BUILD_CUDA)
+configure_package_config_file(${CMAKE_CURRENT_SOURCE_DIR}/cmake/config_cuda.cmake.in
      "${CMAKE_CURRENT_BINARY_DIR}/libompxConfig.cmake"
      INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/libompx)
+endif()
+
+if (LIBOMPX_BUILD_ROCM)
+configure_package_config_file(${CMAKE_CURRENT_SOURCE_DIR}/cmake/config_rocm.cmake.in
+     "${CMAKE_CURRENT_BINARY_DIR}/libompxConfig.cmake"
+     INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/libompx)
+endif()
 
 # Version file
 write_basic_package_version_file(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,12 @@ configure_package_config_file(${CMAKE_CURRENT_SOURCE_DIR}/cmake/config_rocm.cmak
      INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/libompx)
 endif()
 
+if (LIBOMPX_BUILD_ONEAPI)
+configure_package_config_file(${CMAKE_CURRENT_SOURCE_DIR}/cmake/config_oneapi.cmake.in
+     "${CMAKE_CURRENT_BINARY_DIR}/libompxConfig.cmake"
+     INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/libompx)
+endif()
+
 # Version file
 write_basic_package_version_file(
     "${CMAKE_CURRENT_BINARY_DIR}/libompxConfigVersion.cmake"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,11 +28,40 @@ endif()
 # Installation
 
 include(GNUInstallDirs)
+include(CMakePackageConfigHelpers)
+
+# File with target information
 install(EXPORT ompx
     DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/libompx
     NAMESPACE libompx::
-    FILE libompxConfig.cmake
+    FILE libompxTargets.cmake
 )
+
+# File that can be used from the build directory (and is not installed)
+export(EXPORT ompx
+    FILE ${CMAKE_INSTALL_LIBDIR}/cmake/libompx/libompxTargets.cmake
+    NAMESPACE libompx::
+)
+
+# https://cmake.org/cmake/help/latest/guide/importing-exporting/index.html#creating-packages
+# Package file
+configure_package_config_file(${CMAKE_CURRENT_SOURCE_DIR}/cmake/config.cmake.in
+     "${CMAKE_CURRENT_BINARY_DIR}/libompxConfig.cmake"
+     INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/libompx)
+
+# Version file
+write_basic_package_version_file(
+    "${CMAKE_CURRENT_BINARY_DIR}/libompxConfigVersion.cmake"
+    VERSION "${version}"
+    COMPATIBILITY AnyNewerVersion
+    )
+
+# Put package and version files in the install location
+install(FILES
+        "${CMAKE_CURRENT_BINARY_DIR}/libompxConfig.cmake"
+        "${CMAKE_CURRENT_BINARY_DIR}/libompxConfigVersion.cmake"
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/libompx)
+
 
 add_library(libompx::ompx ALIAS ompx)
 

--- a/cmake/config.cmake.in
+++ b/cmake/config.cmake.in
@@ -1,0 +1,9 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/libompxTargets.cmake")
+
+set(CMAKE_CUDA_COMPILER clang++)
+find_package(CUDAToolkit)
+enable_language(CUDA)
+
+check_required_components(libompx)

--- a/cmake/config_cuda.cmake.in
+++ b/cmake/config_cuda.cmake.in
@@ -1,0 +1,9 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/libompxTargets.cmake")
+
+set(CMAKE_CUDA_COMPILER clang++)
+find_package(CUDAToolkit)
+enable_language(CUDA)
+
+check_required_components(libompx)

--- a/cmake/config_oneapi.cmake.in
+++ b/cmake/config_oneapi.cmake.in
@@ -1,0 +1,5 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/libompxTargets.cmake")
+
+check_required_components(libompx)

--- a/cmake/config_rocm.cmake.in
+++ b/cmake/config_rocm.cmake.in
@@ -1,0 +1,9 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/libompxTargets.cmake")
+
+#set(CMAKE_HIP_COMPILER clang++)
+find_package(hip)
+
+
+check_required_components(libompx)

--- a/lib/cuda/CMakeLists.txt
+++ b/lib/cuda/CMakeLists.txt
@@ -23,3 +23,7 @@ thrust_create_target(Thrust)
 add_library(ompx sort_impl.cu sort_impl2.cu sort_by_key_impl.cu inclusive_scan_impl.cu)
 
 target_link_libraries(ompx PUBLIC CUDA::cudart)
+
+# Apparently need to add a directory here in order for the target_include_directory in
+# the parent CMakeLists.txt to work (??)
+target_include_directories(ompx PRIVATE "")

--- a/lib/cuda/CMakeLists.txt
+++ b/lib/cuda/CMakeLists.txt
@@ -7,6 +7,10 @@ set(CMAKE_CUDA_COMPILER clang++)
 find_package(CUDAToolkit)
 enable_language(CUDA)
 
+if (NOT(CUDAToolkit_FOUND))
+    message("CUDA toolkit not found")
+endif()
+
 set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -fgpu-rdc --cuda-gpu-arch=native --offload-new-driver -Xclang -fcuda-allow-variadic-functions")
 
 if (USE_OFFLOAD_LTO)
@@ -18,4 +22,4 @@ thrust_create_target(Thrust)
 
 add_library(ompx sort_impl.cu sort_impl2.cu sort_by_key_impl.cu inclusive_scan_impl.cu)
 
-target_link_libraries(ompx Thrust)
+target_link_libraries(ompx PUBLIC CUDA::cudart)

--- a/lib/rocm/CMakeLists.txt
+++ b/lib/rocm/CMakeLists.txt
@@ -19,5 +19,7 @@ if (USE_OFFLOAD_LTO)
   set(hip_compile_opts "${hip_compile_opts} -foffload-lto")
 endif()
 target_compile_options(ompx PRIVATE "${hip_compile_opts}")
+target_link_libraries(ompx PUBLIC hip::amdhip64)
+
 
 target_include_directories(ompx PRIVATE "${ROCTHRUST_INCLUDE_DIR}")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -32,11 +32,6 @@ foreach(test IN LISTS tests)
   target_compile_options(${test} PRIVATE ${OFFLOAD_COMPILE_OPTIONS})
   target_link_options(${test} PRIVATE ${OFFLOAD_COMPILE_OPTIONS})
 
-  if (LIBOMPX_BUILD_ROCM)
-    target_link_options(${test} PRIVATE -L$ENV{ROCM_PATH}/lib)
-    target_link_libraries(${test} PRIVATE -lamdhip64)
-  endif()
-
   add_test(NAME ${test} COMMAND ${test})
 endforeach()
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -32,11 +32,6 @@ foreach(test IN LISTS tests)
   target_compile_options(${test} PRIVATE ${OFFLOAD_COMPILE_OPTIONS})
   target_link_options(${test} PRIVATE ${OFFLOAD_COMPILE_OPTIONS})
 
-  # Would like to get these forwarded from ompx, but cmake is putting them before libompx
-  if (LIBOMPX_BUILD_CUDA)
-    target_link_options(${test} PRIVATE -L${CUDAToolkit_BIN_DIR}/../lib64)
-    target_link_libraries(${test} PRIVATE -lcuda -lcudart)
-  endif()
   if (LIBOMPX_BUILD_ROCM)
     target_link_options(${test} PRIVATE -L$ENV{ROCM_PATH}/lib)
     target_link_libraries(${test} PRIVATE -lamdhip64)


### PR DESCRIPTION
Improve the CMake configuration files for using libompx from another project with CMake.
Now the dependent libraries (libcuda and libcudart for CUDA and libamdhip64 for HIP) should get added to the configuration.

Both adding libompx to the source directory and building it as a separate project should work.

Currently, the code assumes that only a single backend (CUDA, ROCm, or oneAPI) is present in a particular build.